### PR TITLE
[Proposal Fix] #154 [BUG] The xlsx-renderer stops to work correctly after code compression

### DIFF
--- a/packages/xlsx-renderer/src/CellTemplatePool.ts
+++ b/packages/xlsx-renderer/src/CellTemplatePool.ts
@@ -34,15 +34,15 @@ export class CellTemplatePool {
         DeleteCell,
     ];
 
-    protected instances: { [key: string]: BaseCell } = {};
+    protected instances: Map<CellType, BaseCell> = new Map();
 
     public match(cell: Cell): BaseCell {
-        const type = this.cells.find(x => x.match(cell)) || NormalCell;
+        const type: CellType = this.cells.find(x => x.match(cell)) || NormalCell;
 
-        if (!this.instances[type.name]) {
-            this.instances[type.name] = new type();
-        }
+        if (!this.instances.has(type)) {
+            this.instances.set(type, new type());
+        };
 
-        return this.instances[type.name];
+        return this.instances.get(type) as BaseCell;
     }
 }


### PR DESCRIPTION
The Issue is caused by using the `Function.name` property which during compression is minified.
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/name#javascript_compressors_and_minifiers