### PR TITLE
Added dateMapper with protection against invalid value passes as valid.

### DIFF
--- a/packages/xlsx-import/src/mappers/dateMapper.ts
+++ b/packages/xlsx-import/src/mappers/dateMapper.ts
@@ -1,0 +1,4 @@
+import { ValueMapper } from '../abstracts/ValueMapper';
+
+// noinspection SuspiciousTypeOfGuard
+export const dateMapper: ValueMapper<Date> = value => new Date(typeof value === "string" ? value : "invalid");

--- a/packages/xlsx-import/src/mappers/index.ts
+++ b/packages/xlsx-import/src/mappers/index.ts
@@ -12,3 +12,4 @@ export { integerMapper } from './integerMapper';
 export { booleanMapper } from './booleanMapper';
 export { numberMapper } from './numberMapper';
 export { isValue } from './isValue';
+export { dateMapper } from './dateMapper';

--- a/packages/xlsx-import/tests/unit/mappers/dateMapper.ts
+++ b/packages/xlsx-import/tests/unit/mappers/dateMapper.ts
@@ -1,0 +1,28 @@
+import * as chai from 'chai';
+import { dateMapper } from '../../../src/mappers/dateMapper';
+
+describe('UNIT TEST: src/mappers/', () => {
+    describe('dateMapper', () => {
+        const dataProvider = [
+            // data time
+            { inValue: 'Thu Oct 08 2020 02:00:00 GMT+0200 (Central European Summer Time)', expectedResult: 1602115200000 },
+            { inValue: 'Thu Jan 30 1750 02:00:00 GMT-0900', expectedResult: -6939954000000 },
+            { inValue: 'Thu Jan 30 3125', expectedResult: 36450774000000 },
+
+            // invalid input (out of design) - if input is not string should pass same value forward
+            { inValue: 'asd', expectedResult: NaN },
+            { inValue: null, expectedResult: NaN },
+            { inValue: undefined, expectedResult: NaN },
+            { inValue: true, expectedResult: NaN },
+            { inValue: false, expectedResult: NaN },
+            { inValue: 0, expectedResult: NaN },
+            { inValue: 0x0, expectedResult: NaN },
+        ];
+        dataProvider.forEach(({ inValue, expectedResult }) => {
+            it(`dateMapper for input "${inValue}" SHOULD return "${expectedResult}"`, () => {
+                const date = dateMapper(inValue as string);
+                chai.expect(date.getTime()).eql(expectedResult);
+            });
+        });
+    });
+});

--- a/packages/xlsx-import/tests/unit/mappers/dateMapper.ts
+++ b/packages/xlsx-import/tests/unit/mappers/dateMapper.ts
@@ -20,8 +20,7 @@ describe('UNIT TEST: src/mappers/', () => {
         ];
         dataProvider.forEach(({ inValue, expectedResult }) => {
             it(`dateMapper for input "${inValue}" SHOULD return "${expectedResult}"`, () => {
-                const date = dateMapper(inValue as string);
-                chai.expect(date.getTime()).eql(expectedResult);
+                chai.expect(dateMapper(inValue as string).getTime()).eql(expectedResult);
             });
         });
     });

--- a/packages/xlsx-import/tests/unit/mappers/dateMapper.ts
+++ b/packages/xlsx-import/tests/unit/mappers/dateMapper.ts
@@ -1,5 +1,5 @@
 import * as chai from 'chai';
-import { dateMapper } from '../../../src/mappers/dateMapper';
+import { dateMapper } from '../../../src/mappers';
 
 describe('UNIT TEST: src/mappers/', () => {
     describe('dateMapper', () => {


### PR DESCRIPTION
resolves: https://github.com/Siemienik/XToolset/issues/58

This PR adds dateMapper, which transform string into `Date` Object:

# TODO:

1. [x] Create file `src/mappers/dateMapper.ts` with function matches to type `ValueMapper<Date>`. Which parse value string into Date.
2. [x] reexport it in `src/mappers/index.ts` 
3. [x] Prove that it works in unit test (some present dates, some future, some past & some invalid)
4. [x] Describe it on https://siemienik.com/docs/xlsx-import/#mappers  : [PR](https://github.com/Siemienik/siemienik.github.io/pull/10)
