### PR TITLE
Issue 81: Added getFirstItem method

### DIFF
--- a/packages/xlsx-import/src/IImporter.ts
+++ b/packages/xlsx-import/src/IImporter.ts
@@ -2,7 +2,7 @@ import { ISourceConfig } from './config/ISourceConfig';
 
 export interface IImporter {
     getAllItems<T>(config: ISourceConfig): T[];
-    getFirstItem<T>(config: ISourceConfig): T | T[];
+    getFirstItem<T>(config: ISourceConfig): T;
 }
 
 /** @deprecated Default exports will be removed in January 2021. Please to use brackets (`{ IImporter }`). */

--- a/packages/xlsx-import/src/IImporter.ts
+++ b/packages/xlsx-import/src/IImporter.ts
@@ -2,6 +2,7 @@ import { ISourceConfig } from './config/ISourceConfig';
 
 export interface IImporter {
     getAllItems<T>(config: ISourceConfig): T[];
+    getFirstItem<T>(config: ISourceConfig): T | T[];
 }
 
 /** @deprecated Default exports will be removed in January 2021. Please to use brackets (`{ IImporter }`). */

--- a/packages/xlsx-import/src/Importer.ts
+++ b/packages/xlsx-import/src/Importer.ts
@@ -15,6 +15,12 @@ export class Importer implements IImporter {
 
         return getStrategyByType(type)(config, ws);
     }
+
+    public getFirstItem<T>(config: ISourceConfig): T {
+        const wsData:T[] = this.getAllItems(config);
+        return wsData[0];
+    }
+
 }
 
 /** @deprecated Default exports will be removed in January 2021. Please to use brackets (`{ Importer }`). */

--- a/packages/xlsx-import/tests/integration/vertical-lists.test.ts
+++ b/packages/xlsx-import/tests/integration/vertical-lists.test.ts
@@ -167,4 +167,17 @@ describe('testing vertical list - on file "marsjanie-db"', () => {
         // tslint:disable-next-line:no-console
         console.warn = warnOriginal;
     });
+
+    it(`should return first item of sheet's values array`, async () => {
+        const factory = new ImporterFactory();
+        const importer = await factory.from('tests/data/marsjanie-db.xlsx');
+        const result = importer.getFirstItem(configs.groups);
+
+        const expected = {
+            name: 'Taka se',
+            param: 12,
+        }
+        
+        chai.expect(result).eql(expected);
+    })
 });


### PR DESCRIPTION
resolves #81 

- [x] Add getFirst function into IImporter interface (not in IImporterLegacy)
- [x] Implement getFist in a Importer class (not in ImporterLegacy)
- [x] Update sample in Readme (use getFist) - https://github.com/Siemienik/siemienik.github.io/pull/16
- [x] Update/Add at least one test which check it.

Question:
not quite sure what readme sample is referenced in the todo. Where would be the best place to add a usage sample? 