### PR TITLE
Feature/73 default json mapper response

### DIFF
--- a/packages/xlsx-import/src/mappers/jsonMapper.ts
+++ b/packages/xlsx-import/src/mappers/jsonMapper.ts
@@ -1,9 +1,33 @@
-type JsonMapper = <TJsonResult>(value: string) => TJsonResult | null;
 
-export const jsonMapper: JsonMapper = <TJsonResult extends any>(value: string): TJsonResult | null => {
-    try {
-        return JSON.parse(value);
-    } catch (e) {
-        return null;
+type callSignature = <TJsonResult, TDefaultResult>(value: string) => TJsonResult | TDefaultResult;
+
+type JsonMapper = {
+    default: <TDefaultResult>(defaultResult: TDefaultResult) => JsonMapper
+} & callSignature;
+
+interface IJsonMapperOptions {
+    default: any;
+}
+
+const factory = (options: Readonly<IJsonMapperOptions>): JsonMapper => {
+    const mapper = (json: string) => {
+        try {
+            return JSON.parse(json);
+        } catch (e) {
+            return options.default
+        }
     }
+
+    mapper.default = <TDefaultResult>(defaultResult: TDefaultResult) => factory({
+        ...options,
+        default: defaultResult
+    });
+
+    return mapper;
 };
+
+
+
+export const jsonMapper: JsonMapper = factory({
+    default: null,
+});

--- a/packages/xlsx-import/src/mappers/jsonMapper.ts
+++ b/packages/xlsx-import/src/mappers/jsonMapper.ts
@@ -1,33 +1,31 @@
+type JsonMapperSignature<TDefaultResult> = <TJsonResult>(value: string) => TJsonResult | TDefaultResult;
 
-type callSignature = <TJsonResult, TDefaultResult>(value: string) => TJsonResult | TDefaultResult;
+export type JsonMapper<TJsonResult> = JsonMapperSignature<TJsonResult> & {
+    default: <TDefaultResult>(value: TDefaultResult) => JsonMapper<TDefaultResult>;
+};
 
-type JsonMapper = {
-    default: <TDefaultResult>(defaultResult: TDefaultResult) => JsonMapper
-} & callSignature;
-
-interface IJsonMapperOptions {
-    default: any;
+interface IJsonMapperOptions<TDefaultResult> {
+    default: TDefaultResult;
 }
 
-const factory = (options: Readonly<IJsonMapperOptions>): JsonMapper => {
-    const mapper = (json: string) => {
+const factory = <TDefaultResult>(options: Readonly<IJsonMapperOptions<TDefaultResult>>): JsonMapper<TDefaultResult> => {
+    const mapper: JsonMapper<TDefaultResult> = <TJsonResult>(json: string): TJsonResult | TDefaultResult => {
         try {
             return JSON.parse(json);
         } catch (e) {
-            return options.default
+            return options.default;
         }
-    }
+    };
 
-    mapper.default = <TDefaultResult>(defaultResult: TDefaultResult) => factory({
-        ...options,
-        default: defaultResult
-    });
+    mapper.default = <TJSonResult>(defaultResult: TJSonResult) =>
+        factory<TJSonResult>({
+            ...options,
+            default: defaultResult,
+        });
 
     return mapper;
 };
 
-
-
-export const jsonMapper: JsonMapper = factory({
+export const jsonMapper = factory({
     default: null,
 });

--- a/packages/xlsx-import/tests/unit/mappers/jsonMapper.test.ts
+++ b/packages/xlsx-import/tests/unit/mappers/jsonMapper.test.ts
@@ -25,8 +25,8 @@ describe('UNIT TEST: src/mappers/', () => {
         });
 
         it('Should return default value on error', () => {
-            const mapper = jsonMapper.default({a: 1});
-            chai.expect(mapper('invalid')).eql({a: 1});
-        })
+            const mapper = jsonMapper.default({ a: 1 });
+            chai.expect(mapper('invalid')).eql({ a: 1 });
+        });
     });
 });

--- a/packages/xlsx-import/tests/unit/mappers/jsonMapper.test.ts
+++ b/packages/xlsx-import/tests/unit/mappers/jsonMapper.test.ts
@@ -1,0 +1,32 @@
+import * as chai from 'chai';
+import { jsonMapper } from '../../../src/mappers/jsonMapper';
+
+describe('UNIT TEST: src/mappers/', () => {
+    describe('jsonMapper', () => {
+        const dataProvider = [
+            { inValue: '', expectedResult: null },
+            { inValue: null, expectedResult: null },
+            { inValue: ' ', expectedResult: null },
+            { inValue: 'asd', expectedResult: null },
+            { inValue: 'null', expectedResult: null },
+            { inValue: 'false', expectedResult: false },
+            { inValue: 'true', expectedResult: true },
+            { inValue: '0', expectedResult: 0 },
+            { inValue: '1', expectedResult: 1 },
+            { inValue: '"string"', expectedResult: 'string' },
+            { inValue: "'string'", expectedResult: null },
+            { inValue: '{"a":1}', expectedResult: { a: 1 } },
+            { inValue: '{"a":[1]}', expectedResult: { a: [1] } },
+        ];
+        dataProvider.forEach(({ inValue, expectedResult }) => {
+            it(`jsonMapper for input "${inValue}" SHOULD return "${JSON.stringify(expectedResult)}"`, () => {
+                chai.expect(jsonMapper(inValue as string)).is.eql(expectedResult);
+            });
+        });
+
+        it('Should return default value on error', () => {
+            const mapper = jsonMapper.default({a: 1});
+            chai.expect(mapper('invalid')).eql({a: 1});
+        })
+    });
+});

--- a/packages/xlsx-import/tests/unit/mappers/stringMapper.test.ts
+++ b/packages/xlsx-import/tests/unit/mappers/stringMapper.test.ts
@@ -1,5 +1,5 @@
 import * as chai from 'chai';
-import { isEmpty, isFilled, jsonMapper, lowerCaseMapper, upperCaseMapper } from '../../../src/mappers';
+import { isEmpty, isFilled, lowerCaseMapper, upperCaseMapper } from '../../../src/mappers';
 import { stringMapper } from '../../../src/mappers/stringMapper';
 
 describe('UNIT TEST: src/mappers/', () => {
@@ -58,30 +58,6 @@ describe('UNIT TEST: src/mappers/', () => {
         dataProvider.forEach(({ inValue, expectedResult }) => {
             it(`lowerCaseMapper for input "${inValue}" SHOULD return "${expectedResult}"`, () => {
                 chai.expect(lowerCaseMapper(inValue)).equal(expectedResult);
-            });
-        });
-    });
-
-    // todo move to jsonMapper.test.ts
-    describe('jsonMapper', () => {
-        const dataProvider = [
-            { inValue: '', expectedResult: null },
-            { inValue: null, expectedResult: null },
-            { inValue: ' ', expectedResult: null },
-            { inValue: 'asd', expectedResult: null },
-            { inValue: 'null', expectedResult: null },
-            { inValue: 'false', expectedResult: false },
-            { inValue: 'true', expectedResult: true },
-            { inValue: '0', expectedResult: 0 },
-            { inValue: '1', expectedResult: 1 },
-            { inValue: '"string"', expectedResult: 'string' },
-            { inValue: "'string'", expectedResult: null },
-            { inValue: '{"a":1}', expectedResult: { a: 1 } },
-            { inValue: '{"a":[1]}', expectedResult: { a: [1] } },
-        ];
-        dataProvider.forEach(({ inValue, expectedResult }) => {
-            it(`jsonMapper for input "${inValue}" SHOULD return "${JSON.stringify(expectedResult)}"`, () => {
-                chai.expect(jsonMapper(inValue as string)).is.eql(expectedResult);
             });
         });
     });


### PR DESCRIPTION
Resolves #73 
- [x] Introduce factory similar like in splitMapper:
  - [x] define JsonMapper type
  - [x] wrap mapper into factory function
  - [x] implement setting default
  - [x] produce and export default jsonMapper created by the factory
- [x] prove that it works by covering new changes by unit tests
- [x] describe jsonMapper api in a Readme.md - https://github.com/Siemienik/siemienik.github.io/pull/21
  